### PR TITLE
Remove bastion host creation in China region

### DIFF
--- a/docs/deployment_guide/partner_editable/_settings.adoc
+++ b/docs/deployment_guide/partner_editable/_settings.adoc
@@ -7,7 +7,7 @@
 :doc-year: 2023
 //:partner-contributors: John Smith, {partner-company-name}
 // :other-contributors: Akua Mansa, Trek10
-:aws-contributors: Wei Qiao, AWS Great China Region Solution team
+:aws-contributors: Wei Qiao, AWS Great China Region Solution team; Luna Lu, AWS Great China Region Solutions Architect
 :aws-ia-contributors: Troy Ameigh, AWS Integration & Automation team
 :deployment_time: 60 minutes
 :default_deployment_region: us-east-1

--- a/docs/deployment_guide/partner_editable/pre_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/pre_deployment.adoc
@@ -1,3 +1,38 @@
 //Include any predeployment steps here, such as signing up for a Marketplace AMI or making any changes to a partner account. If there are no predeployment steps, leave this file empty.
 
-//== Predeployment steps
+== Predeployment steps
+
+This solution can be deployed in both AWS global regions and AWS China regions.
+
+* For deployment in global regions: You can leave the `ClickHousePkgS3URI` parameter in the template as the default value *none* and skip this section.
+* For deployment in China regions: Please follow the steps below to upload pre-compiled ClickHouse tgz archives to your own S3 bucket and update the `ClickHousePkgS3URI` parameter.
+
+=== AWS China region pre-deployment steps
+
+. Download pre-complied tgz archives from https://packages.clickhouse.com/tgz/lts/ to your local.
+
+* ClickHouse 23.3.8.21 on X86:
++
+[source,bash]
+----
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-23.3.8.21-amd64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-23.3.8.21-amd64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-23.3.8.21-amd64.tgz
+----
+
+* ClickHouse 23.3.8.21 on ARM:
++
+[source,bash]
+----
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-23.3.8.21-arm64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-23.3.8.21-arm64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-23.3.8.21-arm64.tgz
+----
+
+. Create a S3 bucket in your AWS China account and upload the tgz archives to the bucket.
+* Make sure the bucket is in the same region as the AWS account in which you are deploying this ClickHouse solution.
+* Please upload the tgz archives directly to the bucket. Do not put them in a folder.
+* The bucket containing ARM versions must only contain ARM versions.
+* The bucket containing X86 versions must only contain X86 versions.
+
+. Note down your S3 bucket URI, e.g., `s3://{YOUR_BUCKET}`. Update the `ClickHousePkgS3URI` parameter with your bucket URI when configuring stack details.

--- a/templates/clickhouse-arm-entrypoint-existing-vpc.template.yaml
+++ b/templates/clickhouse-arm-entrypoint-existing-vpc.template.yaml
@@ -498,11 +498,19 @@ Conditions:
   UsingSingleAZ: !Equals [!Ref SingleAvailableZone, '1az']
   IsX86: !Equals [!Ref Architecture, 'X86']
   IsArm: !Equals [!Ref Architecture, 'ARM']
-  IsChinaRegion: !Or 
-      - !Equals 
+  IsChinaRegion: !Or
+    - !Equals
+      - !Ref 'AWS::Region'
+      - cn-north-1
+    - !Equals
+      - !Ref 'AWS::Region'
+      - cn-northwest-1
+  IsNotChinaRegion: !Not
+    - !Or
+      - !Equals
         - !Ref 'AWS::Region'
         - cn-north-1
-      - !Equals 
+      - !Equals
         - !Ref 'AWS::Region'
         - cn-northwest-1
   2NodesCondition: !Equals [!Ref 'ClickHouseNodeCount', '2']
@@ -512,6 +520,7 @@ Conditions:
 Resources:
   BastionStack:
     Type: AWS::CloudFormation::Stack
+    Condition: IsNotChinaRegion
     Properties:
       TemplateURL: 
         Fn::Sub:
@@ -556,11 +565,11 @@ Resources:
         AccessCIDR: !Ref AccessCIDR
         VPCID: !Ref VPCID
         VPCCIDR: !Ref VPCCIDR
-        BastionSecurityGroupID: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+        BastionSecurityGroupID: !If [IsChinaRegion, 'no-sg', !GetAtt BastionStack.Outputs.BastionSecurityGroupID]
   ClickHouseSecret:
     Type: 'AWS::SecretsManager::Secret'
     Properties:
-      Name: !Join ['-',['ClickHouseSecret',!GetAtt BastionStack.Outputs.BastionSecurityGroupID]]
+      Name: !Join ['-',['ClickHouseSecret',!GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup]]
       Description: "This secret has a dynamically generated secret password."
       GenerateSecretString:
         SecretStringTemplate: '{}'
@@ -571,7 +580,7 @@ Resources:
       Tags:
         -
           Key: AppName
-          Value: !Join ['-',['ClickHouseSecret',!GetAtt BastionStack.Outputs.BastionSecurityGroupID]]
+          Value: !Join ['-',['ClickHouseSecret',!GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup]]
   ZookeeperClusterStack: 
     Type: AWS::CloudFormation::Stack
     Properties: 
@@ -586,8 +595,8 @@ Resources:
               - UsingDefaultBucket
               - !Sub '${QSS3BucketName}-${AWS::Region}'
               - !Ref QSS3BucketName
-      Parameters: 
-        RootStackName: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+      Parameters:
+        RootStackName: !GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup
         PrivateSubnetID1: !Ref PrivateSubnet1AID
         PrivateSubnetID2: !Ref PrivateSubnet2AID
         KeyPairName: !Ref KeyPairName
@@ -641,8 +650,8 @@ Resources:
               - UsingDefaultBucket
               - !Sub '${QSS3BucketName}-${AWS::Region}'
               - !Ref QSS3BucketName
-      Parameters: 
-        RootStackName: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+      Parameters:
+        RootStackName: !GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup
         PrivateSubnetID1: !Ref PrivateSubnet1AID
         PrivateSubnetID2: !If
           - UsingSingleAZ 
@@ -695,8 +704,8 @@ Resources:
               - UsingDefaultBucket
               - !Sub '${QSS3BucketName}-${AWS::Region}'
               - !Ref QSS3BucketName
-      Parameters: 
-        RootStackName: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+      Parameters:
+        RootStackName: !GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup
         PrivateSubnetID1: !Ref PrivateSubnet1AID
         PrivateSubnetID2: !If
           - UsingSingleAZ 
@@ -1060,12 +1069,6 @@ Resources:
         ZookeeperInstanceType: !Ref ZookeeperInstanceType
         AlarmEmail: !Ref AlarmEmail
 Outputs:
-  CloudWatchLogs:
-    Description: CloudWatch Logs GroupName. Your SSH logs will be stored here.
-    Value: !GetAtt BastionStack.Outputs.CloudWatchLogs
-  BastionEIP1:
-    Description: Elastic IP 1 for Bastion
-    Value: !GetAtt BastionStack.Outputs.EIP1
   NetworkLoadBalancer2Nodes:
     Condition: 2NodesCondition
     Description: Network Load Balancer with port 8123 in private subnet 1

--- a/templates/clickhouse-arm-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-arm-entrypoint-new-vpc.template.yaml
@@ -515,6 +515,14 @@ Conditions:
   IsX86: !Equals [!Ref Architecture, 'X86']
   IsArm: !Equals [!Ref Architecture, 'ARM']
   IsChinaRegion: !Or
+    - !Equals
+      - !Ref 'AWS::Region'
+      - cn-north-1
+    - !Equals
+      - !Ref 'AWS::Region'
+      - cn-northwest-1
+  IsNotChinaRegion: !Not
+    - !Or
       - !Equals
         - !Ref 'AWS::Region'
         - cn-north-1
@@ -580,6 +588,7 @@ Resources:
         VPCTenancy: default
   BastionStack:
     Type: AWS::CloudFormation::Stack
+    Condition: IsNotChinaRegion
     Properties:
       TemplateURL: !Sub
         - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/cfn-ps-linux-bastion/templates/linux-bastion-entrypoint-existing-vpc.template.yaml'
@@ -618,11 +627,11 @@ Resources:
         AccessCIDR: !Ref AccessCIDR
         VPCID: !GetAtt VPCStack.Outputs.VPCID
         VPCCIDR: !GetAtt VPCStack.Outputs.VPCCIDR
-        BastionSecurityGroupID: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+        BastionSecurityGroupID: !If [IsChinaRegion, 'no-sg', !GetAtt BastionStack.Outputs.BastionSecurityGroupID]
   ClickHouseSecret:
     Type: 'AWS::SecretsManager::Secret'
     Properties:
-      Name: !Join ['-',['ClickHouseSecret',!GetAtt BastionStack.Outputs.BastionSecurityGroupID]]
+      Name: !Join ['-',['ClickHouseSecret',!GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup]]
       Description: "This secret has a dynamically generated secret password."
       GenerateSecretString:
         SecretStringTemplate: '{}'
@@ -633,7 +642,7 @@ Resources:
       Tags:
         -
           Key: AppName
-          Value: !Join ['-',['ClickHouseSecret',!GetAtt BastionStack.Outputs.BastionSecurityGroupID]]
+          Value: !Join ['-',['ClickHouseSecret',!GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup]]
   ZookeeperClusterStack:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -649,7 +658,7 @@ Resources:
               - !Sub '${QSS3BucketName}-${AWS::Region}'
               - !Ref QSS3BucketName
       Parameters:
-        RootStackName: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+        RootStackName: !GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup
         PrivateSubnetID1:
           Fn::GetAtt:
             - VPCStack
@@ -710,7 +719,7 @@ Resources:
               - !Sub '${QSS3BucketName}-${AWS::Region}'
               - !Ref QSS3BucketName
       Parameters:
-        RootStackName: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+        RootStackName: !GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup
         PrivateSubnetID1:
           Fn::GetAtt:
             - VPCStack
@@ -771,7 +780,7 @@ Resources:
               - !Sub '${QSS3BucketName}-${AWS::Region}'
               - !Ref QSS3BucketName
       Parameters:
-        RootStackName: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+        RootStackName: !GetAtt SecurityGroupStack.Outputs.ClickHouseServerSecurityGroup
         PrivateSubnetID1:
           Fn::GetAtt:
             - VPCStack
@@ -1148,12 +1157,6 @@ Outputs:
   S3VPCEndpoint:
     Description: The S3VPCEndpoint for ClickHouse nodes
     Value: !GetAtt VPCStack.Outputs.S3VPCEndpoint
-  CloudWatchLogs:
-    Description: CloudWatch Logs GroupName. Your SSH logs will be stored here.
-    Value: !GetAtt BastionStack.Outputs.CloudWatchLogs
-  BastionEIP1:
-    Description: Elastic IP 1 for Bastion
-    Value: !GetAtt BastionStack.Outputs.EIP1
   NetworkLoadBalancer2Nodes:
     Condition: 2NodesCondition
     Description: Network Load Balancer with port 8123 in private subnet 1


### PR DESCRIPTION
We need to remove bastion host creation in China region because deployment often fail on BastionStack creation due to network issue.....

Tested in both global and China regions.