### PR TITLE
Use s3 cp inside of sync for better security

### DIFF
--- a/scripts/clickhouse-client-install.sh
+++ b/scripts/clickhouse-client-install.sh
@@ -8,6 +8,7 @@
 # ${DemoDataSize}   5
 # ${ClickHouseNodeCount} 6
 # ${GrafanaVersion} 7
+# ${ClickHousePkgS3URI} 8
 
 
 # Install the basics
@@ -25,15 +26,24 @@ sleep 1
 
 yum install yum-utils
 
-sudo yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
-sudo yum install clickhouse-client-$1 -y
+if [ $1 = 23.3.8.21 ] && [ "${8}" != "none" ]; then
+  sudo aws s3 cp ${8}/clickhouse-common-static-23.3.8.21-amd64.tgz ./ --region $4
+  sudo aws s3 cp ${8}/clickhouse-client-23.3.8.21-amd64.tgz ./ --region $4
+  find clickhouse*.tgz -exec tar -xzvf {} \;
 
-sleep 1
-if [ ! -d "/etc/clickhouse-client" ]; then
-    echo "Try to download from https://mirrors.tuna.tsinghua.edu.cn/clickhouse/"
-    rpm --import https://mirrors.tuna.tsinghua.edu.cn/clickhouse/CLICKHOUSE-KEY.GPG
-    yum-config-manager --add-repo https://mirrors.tuna.tsinghua.edu.cn/clickhouse/rpm/stable/x86_64
-    yum install clickhouse-client-$1 -y
+  sudo clickhouse-common-static-$1/install/doinst.sh
+  sudo clickhouse-client-$1/install/doinst.sh
+else
+  sudo yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
+  sudo yum install clickhouse-client-$1 -y
+
+  sleep 1
+  if [ ! -d "/etc/clickhouse-client" ]; then
+      echo "Try to download from https://mirrors.tuna.tsinghua.edu.cn/clickhouse/"
+      rpm --import https://mirrors.aliyun.com/clickhouse/CLICKHOUSE-KEY.GPG
+      yum-config-manager --add-repo https://mirrors.aliyun.com/clickhouse/rpm/stable/
+      yum install clickhouse-client-$1 -y
+  fi
 fi
 
 cd /home/ec2-user/

--- a/scripts/clickhouse-install.sh
+++ b/scripts/clickhouse-install.sh
@@ -41,7 +41,9 @@ ln -s /home/clickhouse/data/log/ /var/log/clickhouse-server
 yum install yum-utils
 
 if [ $1 = 23.3.8.21 ] && [ "${20}" != "none" ]; then
-  sudo aws s3 sync ${20} ./ --region $4
+  sudo aws s3 cp ${20}/clickhouse-common-static-23.3.8.21-amd64.tgz ./ --region $4
+  sudo aws s3 cp ${20}/clickhouse-server-23.3.8.21-amd64.tgz ./ --region $4
+  sudo aws s3 cp ${20}/clickhouse-client-23.3.8.21-amd64.tgz ./ --region $4
   find clickhouse*.tgz -exec tar -xzvf {} \;
 
   sudo clickhouse-common-static-$1/install/doinst.sh

--- a/templates/clickhouse-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-new-vpc.template.yaml
@@ -202,7 +202,7 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x.
     Description: Allowed CIDR block for external Secure Shell (SSH) access to bastion hosts.
-    Default: 10.0.0.0/16
+    Default: 0.0.0.0/0
     Type: String
   KeyPairName:
     Description: Key pairs allow you to connect to your instance after it launches.

--- a/templates/clickhouse.arm.template.yaml
+++ b/templates/clickhouse.arm.template.yaml
@@ -485,7 +485,7 @@ Resources:
             - s3:GetIntelligentTieringConfiguration
             - s3:PutIntelligentTieringConfiguration
             - s3:PutLifecycleConfiguration
-            Resource: !Sub arn:${InstanceRoleArn}:s3:::*
+            Resource: !Sub arn:${InstanceRoleArn}:s3:::*/*
           - Effect: Allow
             Action:
             - ec2:CreateTags

--- a/templates/clickhouse.template.yaml
+++ b/templates/clickhouse.template.yaml
@@ -472,7 +472,7 @@ Resources:
               - s3:GetIntelligentTieringConfiguration
               - s3:PutIntelligentTieringConfiguration
               - s3:PutLifecycleConfiguration
-            Resource: !Sub arn:${InstanceRoleArn}:s3:::*
+            Resource: !Sub arn:${InstanceRoleArn}:s3:::*/*
           - Effect: Allow
             Action:
               - ec2:CreateTags
@@ -781,7 +781,7 @@ Resources:
               fi
             }
             chmod +x clickhouse-client-install.sh
-            ./clickhouse-client-install.sh ${ClickHouseVersion} `python ./find-secret.py secretfile ` ${RootStackName} ${AWS::Region} ${DemoDataSize} ${ClickHouseNodeCount} ${GrafanaVersion} > clickhouse-client-install.log
+            ./clickhouse-client-install.sh ${ClickHouseVersion} `python ./find-secret.py secretfile ` ${RootStackName} ${AWS::Region} ${DemoDataSize} ${ClickHouseNodeCount} ${GrafanaVersion} ${ClickHousePkgS3URI} > clickhouse-client-install.log
              
             cfn_check_result
             /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource AdminAutoScalingGroup --region ${AWS::Region}


### PR DESCRIPTION
* Updated ClickHouse installation script to use s3 cp instead of s3 sync. We don't want to sync everything from the bucket to the instance... Also updated IAM role to have more restricted access to S3 objects.
* Fixed clickhouse-client installation in China region

Tested in China regions and stack deployment succeeded.

