### PR TITLE
chore(deps): Update ClickHouse, Docker, Grafana, Zookeeper, LLVM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: "/.project_automation/functional_tests"
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: "/.project_automation/publication"
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: "/.project_automation/static_tests"
+  schedule:
+    interval: weekly

--- a/.project_automation/functional_tests/Dockerfile
+++ b/.project_automation/functional_tests/Dockerfile
@@ -1,4 +1,8 @@
-FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:4.0
-RUN pip install taskcat yq
-RUN yum install -y yum-utils && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && yum install -y gh
-RUN gem install asciidoctor
+FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
+RUN yum install -y yum-utils \
+ && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo  \
+ && yum remove -y yum-utils \
+ && yum install -y gh \
+ && yum -y clean all && rm -rf /var/cache \
+ && pip3 install --no-cache-dir taskcat yq \
+ && gem install asciidoctor

--- a/.project_automation/publication/Dockerfile
+++ b/.project_automation/publication/Dockerfile
@@ -1,6 +1,10 @@
-FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:4.0
-RUN yum install -y yum-utils && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && yum install -y gh 
-RUN pip install taskcat yq jq awscli
-RUN pip3 install 'copier==8.3.0'
-RUN pip install 'cfn-lint==0.83.2'
-RUN pip install bump2version
+FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
+RUN yum install -y yum-utils \
+ && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo  \
+ && yum remove -y yum-utils \
+ && yum install -y gh \
+ && yum -y clean all && rm -rf /var/cache \
+ && pip3 install --no-cache-dir taskcat yq jq awscli \
+      'copier==9.2.0' \
+      'cfn-lint==0.87.3' \
+      bump2version

--- a/.project_automation/static_tests/Dockerfile
+++ b/.project_automation/static_tests/Dockerfile
@@ -1,4 +1,7 @@
-FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:4.0
-RUN git clone https://github.com/aws-quickstart/qs-cfn-lint-rules.git /tmp/qs-cfn-lint-rules
-RUN cd /tmp/qs-cfn-lint-rules && git checkout 8268db9df3407ccf5383def635bc22e0f99d6b39 && pip install .
+FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
+RUN git clone https://github.com/aws-quickstart/qs-cfn-lint-rules.git /tmp/qs-cfn-lint-rules \
+ && cd /tmp/qs-cfn-lint-rules \
+ && git checkout 2e84337d96e56ee8aea2afa761709b334c2dddaf \
+ && pip3 install --no-cache-dir . \
+ && pip3 install --no-cache-dir cfn-lint==0.87.3
 #RUN cfn-lint -u

--- a/docs/deployment_guide/partner_editable/pre_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/pre_deployment.adoc
@@ -9,24 +9,24 @@ This solution can be deployed in both AWS global regions and AWS China regions.
 
 === AWS China region pre-deployment steps
 
-. Download pre-complied tgz archives from https://packages.clickhouse.com/tgz/lts/ to your local.
+. Download pre-compiled archives from https://packages.clickhouse.com/tgz/lts/ to your local machine.
 
-* ClickHouse 23.3.8.21 on X86:
+* ClickHouse 24.3.3.102 on X86:
 +
 [source,bash]
 ----
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-23.3.8.21-amd64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-23.3.8.21-amd64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-23.3.8.21-amd64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-24.3.3.102-amd64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-24.3.3.102-amd64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-24.3.3.102-amd64.tgz
 ----
 
-* ClickHouse 23.3.8.21 on ARM:
+* ClickHouse 24.3.3.102 on ARM:
 +
 [source,bash]
 ----
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-23.3.8.21-arm64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-23.3.8.21-arm64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-23.3.8.21-arm64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-24.3.3.102-arm64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-24.3.3.102-arm64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-24.3.3.102-arm64.tgz
 ----
 
 . Create a S3 bucket in your AWS China account and upload the tgz archives to the bucket.

--- a/index.html
+++ b/index.html
@@ -1070,22 +1070,22 @@ AWS Cloud.</p>
 <div class="ulist">
 <ul>
 <li>
-<p>ClickHouse 23.3.8.21 on X86:</p>
+<p>ClickHouse 24.3.3.102 on X86:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-23.3.8.21-amd64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-23.3.8.21-amd64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-23.3.8.21-amd64.tgz</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-24.3.3.102-amd64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-24.3.3.102-amd64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-24.3.3.102-amd64.tgz</code></pre>
 </div>
 </div>
 </li>
 <li>
-<p>ClickHouse 23.3.8.21 on ARM:</p>
+<p>ClickHouse 24.3.3.102 on ARM:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-23.3.8.21-arm64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-23.3.8.21-arm64.tgz
-wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-23.3.8.21-arm64.tgz</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">wget https://packages.clickhouse.com/tgz/lts/clickhouse-server-24.3.3.102-arm64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-24.3.3.102-arm64.tgz
+wget https://packages.clickhouse.com/tgz/lts/clickhouse-client-24.3.3.102-arm64.tgz</code></pre>
 </div>
 </div>
 </li>

--- a/scripts/clickhouse-arm-install.sh
+++ b/scripts/clickhouse-arm-install.sh
@@ -47,11 +47,11 @@ chown -R clickhouse.clickhouse /var/lib/clickhouse/
 cd /var/lib/clickhouse/
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
-./llvm.sh 11
-export CC=clang-11
-export CXX=clang++-11
+./llvm.sh 18
+export CC=clang-18
+export CXX=clang++-18
 
-if [ $1 = 23.3.8.21 ] && [ "${20}" != "none" ]; then
+if [ $1 = 24.3.3.102 ] && [ "${20}" != "none" ]; then
   sudo aws s3 sync ${20} ./ --region $4
   find clickhouse*.tgz -exec tar -xzvf {} \;
 
@@ -318,7 +318,7 @@ then
     done
 fi
 
-if [ $1 = 23.3.8.21 ]; then
+if [ $1 = 24.3.3.102 ]; then
     echo "Update the config.xml of $1"
     sed -i '783, 970d' /etc/clickhouse-server/config.xml
 fi

--- a/scripts/clickhouse-client-install.sh
+++ b/scripts/clickhouse-client-install.sh
@@ -14,7 +14,6 @@
 # Install the basics
 yum -y update -y
 yum -y install jq -y
-yum install python3.7 -y
 
 pip3 install awscli --upgrade --user
 echo "export PATH=~/.local/bin:$PATH" >> .bash_profile
@@ -26,9 +25,9 @@ sleep 1
 
 yum install yum-utils
 
-if [ $1 = 23.3.8.21 ] && [ "${8}" != "none" ]; then
-  sudo aws s3 cp ${8}/clickhouse-common-static-23.3.8.21-amd64.tgz ./ --region $4
-  sudo aws s3 cp ${8}/clickhouse-client-23.3.8.21-amd64.tgz ./ --region $4
+if [ $1 = 24.3.3.102 ] && [ "${8}" != "none" ]; then
+  sudo aws s3 cp ${8}/clickhouse-common-static-24.3.3.102-amd64.tgz ./ --region $4
+  sudo aws s3 cp ${8}/clickhouse-client-24.3.3.102-amd64.tgz ./ --region $4
   find clickhouse*.tgz -exec tar -xzvf {} \;
 
   sudo clickhouse-common-static-$1/install/doinst.sh

--- a/scripts/clickhouse-install.sh
+++ b/scripts/clickhouse-install.sh
@@ -40,10 +40,10 @@ ln -s /home/clickhouse/data/log/ /var/log/clickhouse-server
 
 yum install yum-utils
 
-if [ $1 = 23.3.8.21 ] && [ "${20}" != "none" ]; then
-  sudo aws s3 cp ${20}/clickhouse-common-static-23.3.8.21-amd64.tgz ./ --region $4
-  sudo aws s3 cp ${20}/clickhouse-server-23.3.8.21-amd64.tgz ./ --region $4
-  sudo aws s3 cp ${20}/clickhouse-client-23.3.8.21-amd64.tgz ./ --region $4
+if [ $1 = 24.3.3.102 ] && [ "${20}" != "none" ]; then
+  sudo aws s3 cp ${20}/clickhouse-common-static-24.3.3.102-amd64.tgz ./ --region $4
+  sudo aws s3 cp ${20}/clickhouse-server-24.3.3.102-amd64.tgz ./ --region $4
+  sudo aws s3 cp ${20}/clickhouse-client-24.3.3.102-amd64.tgz ./ --region $4
   find clickhouse*.tgz -exec tar -xzvf {} \;
 
   sudo clickhouse-common-static-$1/install/doinst.sh
@@ -311,15 +311,13 @@ then
     done
 fi
 
-# if [ $1 = 21.4.5.46-2 ]; then
-if [ $1 = 21.4.7.3-2 ]; then
+if [ $1 = 22.8.21.38 ]; then
     echo "Update the config.xml of $1"
     sed -i '508, 617d' /etc/clickhouse-server/config.xml
-# elif [ $1 = 21.5.5.12-2 ]; then
-elif [ $1 = 21.5.9.4-2 ]; then
+elif [ $1 = 23.8.14.6 ]; then
     echo "Update the config.xml of $1"
     sed -i '520, 630d' /etc/clickhouse-server/config.xml
-elif [ $1 = 23.3.8.21 ]; then
+elif [ $1 = 24.3.3.102 ]; then
     echo "Update the config.xml of $1"
     sed -i '783, 970d' /etc/clickhouse-server/config.xml
 fi

--- a/scripts/zookeeper-install.sh
+++ b/scripts/zookeeper-install.sh
@@ -10,10 +10,10 @@ sudo ln -s /home/ec2-user/jdk1.8.0_202/bin/java /usr/bin/java
 if [ ! -d "/home/ec2-user/jdk1.8.0_202" ]; then
   rm -rf /usr/local/bin/java
   rm -rf /usr/bin/java
-  wget -P ./ -T 60 https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz
-  tar -xvf /home/ec2-user/openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz
-  sudo ln -s /home/ec2-user/java-se-8u41-ri/bin/java /usr/local/bin/java
-  sudo ln -s /home/ec2-user/java-se-8u41-ri/bin/java /usr/bin/java
+  wget -P ./ -T 60 https://mirrors.tuna.tsinghua.edu.cn/Adoptium/8/jdk/x64/linux/OpenJDK8U-jdk_x64_linux_hotspot_8u412b08.tar.gz
+  tar -xvf /home/ec2-user/OpenJDK8U-jdk_x64_linux_hotspot_8u412b08.tar.gz
+  sudo ln -s /home/ec2-user/jdk8u412-b08/bin/java /usr/local/bin/java
+  sudo ln -s /home/ec2-user/jdk8u412-b08/bin/java /usr/bin/java
 fi
 
 # Avoid deployment issues caused by the version of Zookeeper's frequent changes.

--- a/templates/clickhouse-arm-entrypoint-existing-vpc.template.yaml
+++ b/templates/clickhouse-arm-entrypoint-existing-vpc.template.yaml
@@ -273,10 +273,11 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.7.1'
-    - '3.8.2'
-    Default: '3.8.2'
-    Description: Zookeeper version (3.8.2).
+    - '3.7.2'
+    - '3.8.4'
+    - '3.9.2'
+    Default: '3.9.2'
+    Description: Zookeeper version (3.9.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3
@@ -325,8 +326,8 @@ Parameters:
       - r6g.16xlarge
   ClickHouseVersion:
     AllowedValues:
-      - '23.3.8.21'
-    Default: '23.3.8.21'
+      - '24.3.3.102'
+    Default: '24.3.3.102'
     Description: ClickHouse version.
     Type: String
   ClickHousePkgS3URI:
@@ -442,7 +443,7 @@ Parameters:
     Description: In case of cold option a data can be moved to S3 if local disk free size will be smaller than move_factor * disk_size.
     Type: String
   GrafanaVersion:
-    Default: 8.0.1
+    Default: 8.0.7
     Description: Grafana version (ARM64).
     Type: String
   Port:

--- a/templates/clickhouse-arm-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-arm-entrypoint-new-vpc.template.yaml
@@ -289,10 +289,11 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.7.1'
-    - '3.8.2'
-    Default: '3.8.2'
-    Description: Zookeeper version (3.8.2).
+    - '3.7.2'
+    - '3.8.4'
+    - '3.9.2'
+    Default: '3.9.2'
+    Description: Zookeeper version (3.9.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3
@@ -341,8 +342,8 @@ Parameters:
       - r6g.16xlarge
   ClickHouseVersion:
     AllowedValues:
-      - '23.3.8.21'
-    Default: '23.3.8.21'
+      - '24.3.3.102'
+    Default: '24.3.3.102'
     Description: ClickHouse version.
     Type: String
   ClickHousePkgS3URI:
@@ -458,7 +459,7 @@ Parameters:
     Description: In case of cold option a data can be moved to S3 if local disk free size will be smaller than move_factor * disk_size.
     Type: String
   GrafanaVersion:
-      Default: 8.0.1
+      Default: 8.0.7
       Description: Grafana version (ARM64).
       Type: String
   Port:

--- a/templates/clickhouse-entrypoint-existing-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-existing-vpc.template.yaml
@@ -275,10 +275,11 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.7.1'
-    - '3.8.2'
-    Default: '3.8.2'
-    Description: ZooKeeper version (3.8.2).
+    - '3.7.2'
+    - '3.8.4'
+    - '3.9.2'
+    Default: '3.9.2'
+    Description: Zookeeper version (3.9.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3
@@ -359,14 +360,14 @@ Parameters:
       - i3.16xlarge
   ClickHouseVersion:
     AllowedValues:
-    # - '21.4.5.46-2'
-    # - '21.5.5.12-2'
-    # Default: '21.4.5.46-2'
-    - '21.4.7.3-2'
-    - '21.5.9.4-2'
-    - '23.3.8.21'
-    Default: '23.3.8.21'
-    Description: ClickHouse version (21.4.7, 21.5.9 or 23.3.8.21).
+    # - '21.4.7.3-2'
+    # - '21.5.9.4-2'
+    # Default: '23.3.8.21'
+    - '22.8.21.38'
+    - '23.8.14.6'
+    - '24.3.3.102'
+    Default: '24.3.3.102'
+    Description: ClickHouse version (22.8.21, 23.8.14 or 24.3.3).
     Type: String
   ClickHousePkgS3URI:
     Description:  ClickHouse X86 tgz package storage, e.g., s3://{YOUR_BUCKET}
@@ -481,7 +482,7 @@ Parameters:
     Description: If you use the cold option, you can move data to Amazon S3 if the local disk size is smaller than move_factor multiplied by disk_size.
     Type: String
   GrafanaVersion:
-    Default: 8.0.1-1
+    Default: 8.0.7-1
     Description: Grafana version.
     Type: String
   Port:

--- a/templates/clickhouse-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-new-vpc.template.yaml
@@ -290,10 +290,11 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.7.1'
-    - '3.8.2'
-    Default: '3.8.2'
-    Description: ZooKeeper version (3.8.2).
+    - '3.7.2'
+    - '3.8.4'
+    - '3.9.2'
+    Default: '3.9.2'
+    Description: Zookeeper version (3.9.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3
@@ -374,14 +375,14 @@ Parameters:
       - i3.16xlarge
   ClickHouseVersion:
     AllowedValues:
-    # - '21.4.5.46-2'
-    # - '21.5.5.12-2'
-    # Default: '21.4.5.46-2'
-    - '21.4.7.3-2'
-    - '21.5.9.4-2'
-    - '23.3.8.21'
-    Default: '23.3.8.21'
-    Description: ClickHouse version (21.4.7, 21.5.9 or 23.3.8.21).
+    # - '21.4.7.3-2'
+    # - '21.5.9.4-2'
+    # Default: '23.3.8.21'
+    - '22.8.21.38'
+    - '23.8.14.6'
+    - '24.3.3.102'
+    Default: '24.3.3.102'
+    Description: ClickHouse version (22.8.21, 23.8.14 or 24.3.3).
     Type: String
   ClickHousePkgS3URI:
     Description: ClickHouse X86 tgz package storage, e.g., s3://{YOUR_BUCKET}
@@ -496,7 +497,7 @@ Parameters:
     Description: If you use the cold option, you can move data to Amazon S3 if the local disk size is smaller than move_factor mulitplied by disk_size.
     Type: String
   GrafanaVersion:
-      Default: 8.0.1-1
+      Default: 8.0.7-1
       Description: Grafana version.
       Type: String
   Port:

--- a/templates/clickhouse.arm.template.yaml
+++ b/templates/clickhouse.arm.template.yaml
@@ -209,8 +209,8 @@ Parameters:
       - r6g.16xlarge
   ClickHouseVersion:
     AllowedValues:
-      - '23.3.8.21'
-    Default: '23.3.8.21'
+      - '24.3.3.102'
+    Default: '24.3.3.102'
     Description: ClickHouse version.
     Type: String
   ClickHouseTimezone:
@@ -318,7 +318,7 @@ Parameters:
     Description: The max_data_part_size_bytes for ClickHouse default storage.xml //  Unit is byte, the maximum size of a part that can be stored on any of the volume’s disks.
     Type: String
   GrafanaVersion:
-    Default: 8.0.1-1
+    Default: 8.0.7-1
     Description: Grafana version.
     Type: String
   DemoDataSize:
@@ -833,7 +833,7 @@ Resources:
             export CC=clang-11
             export CXX=clang++-11
 
-            if [ ${ClickHouseVersion} = 23.3.8.21 ] && [ "${ClickHousePkgS3URI}" != "none" ]; then
+            if [ ${ClickHouseVersion} = 24.3.3.102 ] && [ "${ClickHousePkgS3URI}" != "none" ]; then
                 sudo aws s3 sync ${ClickHousePkgS3URI} ./ --region ${AWS::Region}
                 find clickhouse*.tgz -exec tar -xzvf {} \;
 

--- a/templates/clickhouse.template.yaml
+++ b/templates/clickhouse.template.yaml
@@ -235,14 +235,14 @@ Parameters:
       - i3.16xlarge
   ClickHouseVersion:
     AllowedValues:
-    # - '21.4.5.46-2'
-    # - '21.5.5.12-2'
-    # Default: '21.4.5.46-2'
-    - '21.4.7.3-2'
-    - '21.5.9.4-2'
-    - '23.3.8.21'
-    Default: '23.3.8.21'
-    Description: ClickHouse version (21.4.7, 21.5.9 or 23.3.8.21).
+    # - '21.4.7.3-2'
+    # - '21.5.9.4-2'
+    # Default: '23.3.8.21'
+    - '22.8.21.38'
+    - '23.8.14.6'
+    - '24.3.3.102'
+    Default: '24.3.3.102'
+    Description: ClickHouse version (22.8.21, 23.8.14 or 24.3.3).
     Type: String
   ClickHouseTimezone:
     Default: Asia/Shanghai
@@ -344,7 +344,7 @@ Parameters:
     Description: The max_data_part_size_bytes for ClickHouse default storage.xml //  Unit is byte, the maximum size of a part that can be stored on any of the volume’s disks.
     Type: String
   GrafanaVersion:
-    Default: 8.0.1-1
+    Default: 8.0.7-1
     Description: Grafana version.
     Type: String
   DemoDataSize:

--- a/templates/zookeeper.template.yaml
+++ b/templates/zookeeper.template.yaml
@@ -139,10 +139,11 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.7.1'
-    - '3.8.2'
-    Default: '3.8.2'
-    Description: ZooKeeper version (3.8.2).
+    - '3.7.2'
+    - '3.8.4'
+    - '3.9.2'
+    Default: '3.9.2'
+    Description: Zookeeper version (3.9.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3


### PR DESCRIPTION
### Updates
* ClickHouse 21.4.7.3-2 to 22.8.21.38 (latest lts)
* ClickHouse 21.5.9.4-2 to 23.8.14.6 (latest lts)
* ClickHouse 23.3.8.21 to 24.3.3.102 (latest lts)
* Grafana 8.0.1 to 8.0.7 (11 would be four years newer, [possible?](https://grafana.com/grafana/plugins/vertamedia-clickhouse-datasource/))
* Zookeeper 3.7.1 to 3.7.2
* Zookeeper 3.8.2 to 3.8.4
* Zookeeper 3.9.2 (new default)
* Fallback JDK 8u41 to 8u412
* LLVM 11 to 18
* amazonlinux2 to amazonlinux2023
* pip dependencies
* qs-cfn-lint-rules (but _cfn-lint_ is overridden to latest 0.87.3)

### Improvements
* Smaller Docker images
* Let Dependabot update Dockerfiles

### TODO
* Test everything 😅 Especially *install.sh, i.e. the sed deletions haven't been updated
* JDK 8u202 is extremely old, migrating to another Java distribution is important
* After this PR has been merged, other repos can be updated too